### PR TITLE
Handle multiple and expanded sources properly

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,13 +64,21 @@ module.exports = function(grunt) {
                 src: 'test/files/8',
                 dest: 'eight'
             },
-
+            nineAndTen: {
+                src: ['test/files/9', 'test/files/10'],
+                dest: 'tmp/tmp/tmp/'
+            },
             eleven: {
                 src: 'test/files/11',
                 dest: 'tmp/eleven',
                 options: {
                     ignore: true,
                 }
+            },
+            twoHundreds: {
+                expand: true,
+                src: 'test/files/20*',
+                dest: 'tmp/20/'
             }
         },
 
@@ -91,10 +99,21 @@ module.exports = function(grunt) {
 
     // Whenever the "test" task is run, first clean the "tmp" dir, then run this
     // plugin's task(s), then test the result.
-    grunt.registerTask('test', ['clean', 'make', 'rename', 'nodeunit', 'clean']);
+    grunt.registerTask('test', ['clean', 'make', 'rename', 'sleep', 'nodeunit', 'clean']);
 
     // By default, lint and run all tests.
     grunt.registerTask('default', ['jshint', 'test']);
+
+    grunt.registerTask('sleep', function () {
+        var done = this.async();
+
+        grunt.file.write('test/files/sleep', 'Sleeping');
+
+        setTimeout(function() {
+            grunt.file.write('test/files/sleep', 'Slept');
+            done();
+        }, 10000);
+    });
 
     grunt.registerTask('make', function () {
         var p = './test/files/';
@@ -102,5 +121,9 @@ module.exports = function(grunt) {
         for(var i = 1; i <= 10; i++) {
             grunt.file.write(path.join(p, '' + i, ''));
         }
+
+        grunt.file.write(path.join(p, '201', ''));
+        grunt.file.write(path.join(p, '202', ''));
+        grunt.file.write(path.join(p, '203', ''));
     });
 };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
         "test": "grunt test"
     },
 
-    "dependencies": {},
+    "dependencies": {
+        "async": "~0.9.0"
+    },
 
     "devDependencies": {
         "grunt-contrib-jshint": "~0.1.1",

--- a/test/rename_test.js
+++ b/test/rename_test.js
@@ -82,4 +82,27 @@ exports.rename = {
         test.ok(!grunt.file.exists('test/files/8'), 'test/files/8 should NOT exist');
         test.done();
     },
+
+    nineAndTen: function(test) {
+        test.expect(5);
+        test.ok(grunt.file.exists('tmp/tmp/tmp/9'), 'tmp/tmp/tmp/9 should exist');
+        test.ok(grunt.file.exists('tmp/tmp/tmp/10'), 'tmp/tmp/tmp/10 should exist');
+        test.ok(!grunt.file.exists('test/files/9'), 'test/files/9 should NOT exist');
+        test.ok(!grunt.file.exists('test/files/10'), 'test/files/10 should NOT exist');
+        test.equal(grunt.file.read('test/files/sleep'), 'Slept', 'Sleep should have finished');
+        test.done();
+    },
+
+    twoHundreds: function(test) {
+        test.expect(7);
+        test.ok(grunt.file.exists('tmp/20/test/files/201'), 'tmp/20/test/files/201 should exist');
+        test.ok(grunt.file.exists('tmp/20/test/files/202'), 'tmp/20/test/files/202 should exist');
+        test.ok(grunt.file.exists('tmp/20/test/files/203'), 'tmp/20/test/files/203 should exist');
+        test.ok(!grunt.file.exists('test/files/201'), 'test/files/201 should NOT exist');
+        test.ok(!grunt.file.exists('test/files/202'), 'test/files/202 should NOT exist');
+        test.ok(!grunt.file.exists('test/files/203'), 'test/files/203 should NOT exist');
+        test.equal(grunt.file.read('test/files/sleep'), 'Slept', 'Sleep should have finished');
+        test.done();
+    },
+
 };


### PR DESCRIPTION
`done` should only be called once, but was called multiple times if either:
- The `src` option was set to an array of files.
- The `expand` option was enabled and that expanded to more than one file.

This would break future async grunt tasks. The destination would also be set to the same filename for all elements in `src` arrays, which is fixed in this branch too.
