### PR TITLE
Add 'execSync' option

### DIFF
--- a/tasks/rename.js
+++ b/tasks/rename.js
@@ -13,10 +13,12 @@ var fs = require('fs'),
 
 module.exports = function(grunt) {
     grunt.registerMultiTask('rename', 'Move and/or rename files.', function() {
-        var done = this.async(),
-            options = this.options({
+        var options = this.options({
                 ignore: false,
+                execSync: false
             });
+            
+        var done = options.execSync ? (function(){}) : this.async();
 
         //console.log(options);
 


### PR DESCRIPTION
If execSync=true, run the 'rename' task synchronously

This is a necessary flag in order to run 'watch' task after this rename task. Tested locally against latest grunt-contrib-watch v0.6.1.

An issue is also opened on the grunt-contrib-watch repo, gruntjs/grunt-contrib-watch#409

Usage example:
```javascript
rename: {
           options:{
                execSync: true
           },
           foo: {
               src: 'foo/src'
               dest: 'foo/dest'
           }
}
```