### PR TITLE
Fix: repeatedly execute `done`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,55 +1,48 @@
 {
-    "name": "grunt-rename",
-    "description": "Move and/or rename files.",
-    "version": "0.1.4",
-    "homepage": "https://github.com/jdavis/grunt-rename",
-
-    "author": {
-        "name": "Josh Davis",
-        "email": "josh@joshldavis.com",
-        "url": "http://joshldavis.com"
-    },
-
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/jdavis/grunt-rename.git"
-    },
-
-    "bugs": {
-        "url": "https://github.com/jdavis/grunt-rename/issues"
-    },
-
-    "licenses": [{
-        "type": "MIT",
-        "url": "https://github.com/jdavis/grunt-rename/blob/master/LICENSE-MIT"
-    }],
-
-    "main": "Gruntfile.js",
-
-    "engines": {
-        "node": ">= 0.8.0"
-    },
-
-    "scripts": {
-        "test": "grunt test"
-    },
-
-    "dependencies": {},
-
-    "devDependencies": {
-        "grunt-contrib-jshint": "~0.1.1",
-        "grunt-contrib-clean": "~0.4.0",
-        "grunt-contrib-nodeunit": "~0.1.2",
-        "grunt": "~0.4.1"
-    },
-
-    "peerDependencies": {
-        "grunt": "~0.4.1"
-    },
-
-    "keywords": [
-        "gruntplugin",
-        "move",
-        "rename"
-    ]
+  "name": "grunt-rename",
+  "description": "Move and/or rename files.",
+  "version": "0.1.4",
+  "homepage": "https://github.com/jdavis/grunt-rename",
+  "author": {
+    "name": "Josh Davis",
+    "email": "josh@joshldavis.com",
+    "url": "http://joshldavis.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/jdavis/grunt-rename.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jdavis/grunt-rename/issues"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/jdavis/grunt-rename/blob/master/LICENSE-MIT"
+    }
+  ],
+  "main": "Gruntfile.js",
+  "engines": {
+    "node": ">= 0.8.0"
+  },
+  "scripts": {
+    "test": "grunt test"
+  },
+  "dependencies": {
+    "async": "^1.4.2"
+  },
+  "devDependencies": {
+    "grunt-contrib-jshint": "~0.1.1",
+    "grunt-contrib-clean": "~0.4.0",
+    "grunt-contrib-nodeunit": "~0.1.2",
+    "grunt": "~0.4.1"
+  },
+  "peerDependencies": {
+    "grunt": "~0.4.1"
+  },
+  "keywords": [
+    "gruntplugin",
+    "move",
+    "rename"
+  ]
 }


### PR DESCRIPTION
Repeatedly execute `done` when rename files.
It affectes other tasks which is async behind.
